### PR TITLE
Add samba.tv domains

### DIFF
--- a/smart-tv.txt
+++ b/smart-tv.txt
@@ -83,3 +83,5 @@
 0.0.0.0 osb.samsungqbe.com
 0.0.0.0 gld.push.samsungosp.com
 0.0.0.0 sas.samsungcloudsolution.com
+0.0.0.0 events.cid.samba.tv
+0.0.0.0 platform.cid.samba.tv


### PR DESCRIPTION
## Summary
Basically spyware built-in to provide targeted ads on Sony smart TV's.

Details:
* https://www.sony.com/electronics/support/articles/00182856
* https://www.reddit.com/r/bravia/comments/87sob0/what_is_samba_tv_worth_enabling/


## Checklist

- [X] I have verified that I have not modified any files inside the `alt-version` folder (automated code will automatically update those files)

- [X] I have verified that I have not modified any files inside the `dnsmasq-version` folder (automated code will automatically update those files)
